### PR TITLE
(2주차) 게시글 관리 API CRUD 기능 구현 - 이승연

### DIFF
--- a/이승연/build.gradle
+++ b/이승연/build.gradle
@@ -28,6 +28,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.h2database:h2'
+    implementation 'org.postgresql:postgresql:42.6.0'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'

--- a/이승연/src/main/java/org/hanghae99/tddframeworkstudy/TddFrameworkStudyApplication.java
+++ b/이승연/src/main/java/org/hanghae99/tddframeworkstudy/TddFrameworkStudyApplication.java
@@ -2,8 +2,10 @@ package org.hanghae99.tddframeworkstudy;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
+@EnableJpaAuditing
 public class TddFrameworkStudyApplication {
 
     public static void main(String[] args) {

--- a/이승연/src/main/java/org/hanghae99/tddframeworkstudy/base/dto/BaseResponseBody.java
+++ b/이승연/src/main/java/org/hanghae99/tddframeworkstudy/base/dto/BaseResponseBody.java
@@ -1,0 +1,21 @@
+package org.hanghae99.tddframeworkstudy.base.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@Getter @Setter
+public class BaseResponseBody<T> {
+    private LocalDateTime timestamp;
+    private T content;
+
+    public BaseResponseBody() {
+        this.timestamp = LocalDateTime.now();
+    }
+
+    public BaseResponseBody(T content) {
+        this.timestamp = LocalDateTime.now();
+        this.content = content;
+    }
+}

--- a/이승연/src/main/java/org/hanghae99/tddframeworkstudy/base/entity/BaseEntity.java
+++ b/이승연/src/main/java/org/hanghae99/tddframeworkstudy/base/entity/BaseEntity.java
@@ -1,0 +1,33 @@
+package org.hanghae99.tddframeworkstudy.base.entity;
+
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class) // @CreatedDate, @LastModifiedDate 사용하기 위해 리스너 추가
+public class BaseEntity {
+
+    Boolean isDelete = false;
+
+    @CreatedDate
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    private LocalDateTime modifiedAt;
+}
+
+
+
+
+
+
+

--- a/이승연/src/main/java/org/hanghae99/tddframeworkstudy/post/controller/PostController.java
+++ b/이승연/src/main/java/org/hanghae99/tddframeworkstudy/post/controller/PostController.java
@@ -1,0 +1,43 @@
+package org.hanghae99.tddframeworkstudy.post.controller;
+
+import org.hanghae99.tddframeworkstudy.post.entity.PostEntity;
+import org.hanghae99.tddframeworkstudy.post.service.PostService;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/post")
+public class PostController {
+
+    private final PostService postService;
+
+    public PostController(PostService postService) {
+        this.postService = postService;
+    }
+
+    @PostMapping
+    public PostEntity save(@RequestBody PostEntity postEntity) {
+        return postService.save(postEntity);
+    }
+
+    @GetMapping("/{id}")
+    public PostEntity findById(@PathVariable Long id) {
+        return postService.findById(id);
+    }
+
+    @GetMapping
+    public List<PostEntity> findAll() {
+        return postService.findAll();
+    }
+
+    @PutMapping("/{id}")
+    public PostEntity update(@PathVariable Long id, @RequestBody PostEntity postEntity) {
+        return postService.update(id, postEntity);
+    }
+
+    @DeleteMapping("/{id}")
+    public void delete(@PathVariable Long id) {
+        postService.delete(id);
+    }
+}

--- a/이승연/src/main/java/org/hanghae99/tddframeworkstudy/post/controller/PostController.java
+++ b/이승연/src/main/java/org/hanghae99/tddframeworkstudy/post/controller/PostController.java
@@ -1,7 +1,12 @@
 package org.hanghae99.tddframeworkstudy.post.controller;
 
+import org.hanghae99.tddframeworkstudy.base.dto.BaseResponseBody;
 import org.hanghae99.tddframeworkstudy.post.entity.PostEntity;
 import org.hanghae99.tddframeworkstudy.post.service.PostService;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.util.MultiValueMap;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -22,22 +27,46 @@ public class PostController {
     }
 
     @GetMapping("/{id}")
-    public PostEntity findById(@PathVariable Long id) {
-        return postService.findById(id);
+    public ResponseEntity<BaseResponseBody<PostEntity>> findById(@PathVariable Long id) {
+
+        PostEntity savedPost = postService.findById(id);
+
+        MultiValueMap<String, String> headers = new HttpHeaders();
+        headers.add("Content-Type", "application/json");
+
+        return new ResponseEntity<>(new BaseResponseBody<>(savedPost), headers, HttpStatus.CREATED);
     }
 
     @GetMapping
-    public List<PostEntity> findAll() {
-        return postService.findAll();
+    public ResponseEntity<BaseResponseBody<List<PostEntity>>> findAll() {
+
+        List<PostEntity> posts = postService.findAll();
+
+        MultiValueMap<String, String> headers = new HttpHeaders();
+        headers.add("Content-Type", "application/json");
+
+        return new ResponseEntity<>(new BaseResponseBody<>(posts), headers, HttpStatus.OK);
     }
 
     @PutMapping("/{id}")
-    public PostEntity update(@PathVariable Long id, @RequestBody PostEntity postEntity) {
-        return postService.update(id, postEntity);
+    public ResponseEntity<BaseResponseBody<PostEntity>> update(@PathVariable Long id, @RequestBody PostEntity postEntity) {
+
+        PostEntity updatedPost = postService.update(id, postEntity);
+
+        MultiValueMap<String, String> headers = new HttpHeaders();
+        headers.add("Content-Type", "application/json");
+
+        return new ResponseEntity<>(new BaseResponseBody<>(updatedPost), headers, HttpStatus.OK);
     }
 
     @DeleteMapping("/{id}")
-    public void delete(@PathVariable Long id) {
+    public ResponseEntity<Object> delete(@PathVariable Long id) {
+
         postService.delete(id);
+
+        MultiValueMap<String, String> headers = new HttpHeaders();
+        headers.add("Content-Type", "application/json");
+
+        return new ResponseEntity<>(new BaseResponseBody<>(), headers, HttpStatus.NO_CONTENT);
     }
 }

--- a/이승연/src/main/java/org/hanghae99/tddframeworkstudy/post/entity/PostEntity.java
+++ b/이승연/src/main/java/org/hanghae99/tddframeworkstudy/post/entity/PostEntity.java
@@ -1,0 +1,29 @@
+package org.hanghae99.tddframeworkstudy.post.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.springframework.data.annotation.CreatedDate;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter @Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class PostEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String title;
+
+    @Lob
+    private String content;
+
+    @CreatedDate
+    private LocalDateTime createdAt = LocalDateTime.now();
+
+}

--- a/이승연/src/main/java/org/hanghae99/tddframeworkstudy/post/entity/PostEntity.java
+++ b/이승연/src/main/java/org/hanghae99/tddframeworkstudy/post/entity/PostEntity.java
@@ -1,29 +1,20 @@
 package org.hanghae99.tddframeworkstudy.post.entity;
 
 import jakarta.persistence.*;
-import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 import lombok.Setter;
-import org.springframework.data.annotation.CreatedDate;
+import org.hanghae99.tddframeworkstudy.base.entity.BaseEntity;
 
-import java.time.LocalDateTime;
-
+@Getter
+@Setter
+@Table(name = "post")
 @Entity
-@Getter @Setter
-@NoArgsConstructor
-@AllArgsConstructor
-public class PostEntity {
+public class PostEntity extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     private String title;
 
-    @Lob
     private String content;
-
-    @CreatedDate
-    private LocalDateTime createdAt = LocalDateTime.now();
-
 }

--- a/이승연/src/main/java/org/hanghae99/tddframeworkstudy/post/repository/PostRepository.java
+++ b/이승연/src/main/java/org/hanghae99/tddframeworkstudy/post/repository/PostRepository.java
@@ -1,0 +1,7 @@
+package org.hanghae99.tddframeworkstudy.post.repository;
+
+import org.hanghae99.tddframeworkstudy.post.entity.PostEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PostRepository extends JpaRepository<PostEntity, Long> {
+}

--- a/이승연/src/main/java/org/hanghae99/tddframeworkstudy/post/service/PostService.java
+++ b/이승연/src/main/java/org/hanghae99/tddframeworkstudy/post/service/PostService.java
@@ -1,0 +1,14 @@
+package org.hanghae99.tddframeworkstudy.post.service;
+
+import org.hanghae99.tddframeworkstudy.post.entity.PostEntity;
+
+import java.util.List;
+
+public interface PostService {
+
+    PostEntity save(PostEntity postEntity);
+    PostEntity findById(Long id);
+    List<PostEntity> findAll();
+    PostEntity update(Long id, PostEntity postEntity);
+    void delete(Long id);
+}

--- a/이승연/src/main/java/org/hanghae99/tddframeworkstudy/post/service/PostServiceImpl.java
+++ b/이승연/src/main/java/org/hanghae99/tddframeworkstudy/post/service/PostServiceImpl.java
@@ -1,0 +1,57 @@
+package org.hanghae99.tddframeworkstudy.post.service;
+
+import org.hanghae99.tddframeworkstudy.post.entity.PostEntity;
+import org.hanghae99.tddframeworkstudy.post.repository.PostRepository;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Optional;
+
+@Service
+public class PostServiceImpl implements PostService {
+
+    private final PostRepository postRepository;
+
+    public PostServiceImpl(PostRepository postRepository) {
+        this.postRepository = postRepository;
+    }
+
+    @Override
+    public PostEntity save(PostEntity postEntity) {
+
+        return postRepository.save(postEntity);
+    }
+
+    @Override
+    public PostEntity findById(Long id) {
+
+        Optional<PostEntity> newPost = postRepository.findById(id);
+
+        return newPost.orElseThrow(() -> new RuntimeException("NOT FOUND"));
+    }
+
+    @Override
+    public List<PostEntity> findAll() {
+
+        return postRepository.findAll();
+    }
+
+    @Override
+    public PostEntity update(Long id, PostEntity postEntity) {
+
+        PostEntity existingPost = postRepository.findById(id).orElseThrow(() -> new RuntimeException("NOT FOUND"));
+
+        existingPost.setTitle(postEntity.getTitle());
+        existingPost.setContent(postEntity.getContent());
+
+        return postRepository.save(existingPost);
+    }
+
+    @Override
+    public void delete(Long id) {
+
+        PostEntity existingPost = postRepository.findById(id).orElseThrow(() -> new RuntimeException("NOT FOUND"));
+
+        postRepository.delete(existingPost);
+    }
+}

--- a/이승연/src/main/java/org/hanghae99/tddframeworkstudy/post/service/PostServiceImpl.java
+++ b/이승연/src/main/java/org/hanghae99/tddframeworkstudy/post/service/PostServiceImpl.java
@@ -35,16 +35,21 @@ public class PostServiceImpl implements PostService {
     @Override
     public List<PostEntity> findAll() {
 
-        return postRepository.findAll();
+        return postRepository.findAll(Sort.by(Sort.Direction.DESC, "createdAt"));
     }
 
+    @Transactional
     @Override
     public PostEntity update(Long id, PostEntity postEntity) {
 
         PostEntity existingPost = postRepository.findById(id).orElseThrow(() -> new RuntimeException("NOT FOUND"));
 
-        existingPost.setTitle(postEntity.getTitle());
-        existingPost.setContent(postEntity.getContent());
+        if (postEntity.getTitle() != null) {
+            existingPost.setTitle(postEntity.getTitle());
+        }
+        if (postEntity.getContent() != null) {
+            existingPost.setContent(postEntity.getContent());
+        }
 
         return postRepository.save(existingPost);
     }

--- a/이승연/src/main/java/org/hanghae99/tddframeworkstudy/post/service/PostServiceImpl.java
+++ b/이승연/src/main/java/org/hanghae99/tddframeworkstudy/post/service/PostServiceImpl.java
@@ -2,7 +2,9 @@ package org.hanghae99.tddframeworkstudy.post.service;
 
 import org.hanghae99.tddframeworkstudy.post.entity.PostEntity;
 import org.hanghae99.tddframeworkstudy.post.repository.PostRepository;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.Optional;

--- a/이승연/src/main/resources/application.properties
+++ b/이승연/src/main/resources/application.properties
@@ -1,1 +1,0 @@
-spring.application.name=tdd-framework-study

--- a/이승연/src/main/resources/application.yml
+++ b/이승연/src/main/resources/application.yml
@@ -1,0 +1,15 @@
+spring:
+  application:
+    name=: tdd-framework-study
+  jpa:
+    hibernate:
+      ddl-auto: update
+    show-sql: true # SQL 쿼리 출력
+    properties:
+      hibernate:
+        default_schema: tddframeworkstudy
+  datasource:
+    url: jdbc:postgresql://localhost:5432/tddframeworkstudy
+    username: tddframeworkstudyuser
+    password:
+    driver-class-name: org.postgresql.Driver


### PR DESCRIPTION
## 작업 내용
게시글 관리 CRUD 기능을 다음과 같이 구현했습니다.
1. #5 게시글 목록 조회 API (`GET /api/post`)
2. #6 게시글 작성 API (`POST /api/post`)
3. #7 게시글 상세 조회 API (`GET /api/post/{id}`)
4. #8 게시글 수정 API (`PUT /api/post/{id}`)
5. #9 게시글 삭제 API (`DELETE /api/post/{id}`)

## 주요 변경 사항
- Post 엔티티 추가: title, content, createdAt 필드 포함
- PostController CRUD 엔드포인트 구현
- PostService 인터페이스 및 구현 클래스 추가
- PostRepository: Spring Data JPA로 구현

## 다음 작업 계획
- API에 대한 테스트 코드 작성 및 추가
- API 요청 및 응답을 DTO(`PostReq`, `PostRes`)로 관리하도록 로직 추가
- 예외 처리 로직 개선

## 요청사항
- 엔티티 설계와 API의 응답 형식에 대해 피드백 부탁드립니다.
